### PR TITLE
Update v3 to use readFileAsString method

### DIFF
--- a/src/lib/ImageCaptions3.js
+++ b/src/lib/ImageCaptions3.js
@@ -25,10 +25,12 @@ ImageCaptions3.prototype.readAllImages = function (book) {
   var promises = [];
 
   var pageIndex = 0;
-  book.summary.walk(function (page) {
-    var currentPageIndex = pageIndex++;
 
-    promises.push(book.pages[page.ref].read().then(function () {
+  book.summary.walk(function (page) {
+    var currentPageIndex = pageIndex++,
+          pageText = book.readFileAsString(page.ref);
+    
+    promises.push(pageText.then(function (pageContent) {
       var pageImages = [];
 
       var reg = new RegExp(/!\[(.*?)\]\((.*?)(?:\s+"(.*)")?\)/gmi);
@@ -36,7 +38,7 @@ ImageCaptions3.prototype.readAllImages = function (book) {
 
       var index = 1;
 
-      while ((result = reg.exec(book.pages[page.ref].content)) !== null) {
+      while ((result = reg.exec(pageContent)) !== null) {
         var image = {alt: result[1], url: result[2]};
         if (result[3]) {
           image.title = result[3];


### PR DESCRIPTION
Fallowing the restoration on the of `summary.walk` on 3.0.0-pre.14 (See GitBookIO/gitbook#1285), there were still errors trying to access `book.pages`, so this uses the officially supported API. 

Note that this _does_ break compatibility with 3.0.0-pre.9, but it doesn't seem like it would be worth the effort to maintain compatibility there.
